### PR TITLE
Macos download fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,21 +9,21 @@ lucky:
 	./.imfeelinglucky.sh
 
 get_haproxy:
-	wget https://github.com/RedTurtle/deployments.buildout.haproxy/archive/master.zip
+	wget -O master.zip https://github.com/RedTurtle/deployments.buildout.haproxy/archive/master.zip
 	unzip master.zip
 	mv deployments.buildout.haproxy-master/ components/haproxy
 	rm master.zip
 	@echo "TIP: uncomment component lines in supervisor programs"
 
 get_plone:
-	wget https://github.com/RedTurtle/deployments.buildout.plone/archive/master.zip
+	wget -O master.zip https://github.com/RedTurtle/deployments.buildout.plone/archive/master.zip
 	unzip master.zip
 	mv deployments.buildout.plone-master/ components/plone
 	rm master.zip
 	@echo "TIP: uncomment component lines in supervisor programs"
 
 get_varnish:
-	wget https://github.com/RedTurtle/deployments.buildout.varnish/archive/master.zip
+	wget -O master.zip https://github.com/RedTurtle/deployments.buildout.varnish/archive/master.zip
 	unzip master.zip
 	mv deployments.buildout.varnish-master/ components/varnish
 	rm master.zip

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ How to make a copy of this buildout
 -----------------------------------
 Launch those lines
 ```bash
-wget https://github.com/RedTurtle/deployments.buildout.production/archive/master.zip
+wget -O master.zip https://github.com/RedTurtle/deployments.buildout.production/archive/master.zip
 unzip master.zip
 rm master.zip
 cd deployments.buildout.production-master


### PR DESCRIPTION
On macos running a `wget` of github archives returns a wrong named downlod file (e.g: "master" instead of "master.zip")